### PR TITLE
build!: migrate from jest to native node:test

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,26 +14,6 @@ module.exports = {
 		"plugin:security/recommended-legacy",
 		"prettier",
 	],
-	overrides: [
-		{
-			extends: ["plugin:jest/recommended", "plugin:jest/style"],
-			files: ["src/**/*.test.js"],
-			plugins: ["jest"],
-			rules: {
-				"jest/no-duplicate-hooks": "error",
-				"jest/no-test-return-statement": "error",
-				"jest/prefer-comparison-matcher": "error",
-				"jest/prefer-each": "warn",
-				"jest/prefer-equality-matcher": "error",
-				"jest/prefer-expect-resolves": "error",
-				"jest/prefer-hooks-in-order": "error",
-				"jest/prefer-hooks-on-top": "error",
-				"jest/prefer-mock-promise-shorthand": "error",
-				"jest/prefer-spy-on": "error",
-				"jest/require-top-level-describe": "error",
-			},
-		},
-	],
 	parserOptions: {
 		ecmaVersion: 2023,
 		// Explicitly tell ESLint to parse JavaScript as CommonJS, as airbnb-base sets this to "modules" for ECMAScript
@@ -50,6 +30,19 @@ module.exports = {
 		"jsdoc/require-description-complete-sentence": "error",
 		"jsdoc/require-hyphen-before-param-description": "error",
 		"no-multiple-empty-lines": ["error", { max: 1 }],
+		"no-restricted-syntax": [
+			"error",
+			{
+				selector: "LabeledStatement",
+				message:
+					"Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.",
+			},
+			{
+				selector: "WithStatement",
+				message:
+					"`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
+			},
+		],
 		"prefer-destructuring": ["error", { object: true, array: false }],
 		"promise/prefer-await-to-callbacks": "warn",
 		"promise/prefer-await-to-then": "warn",

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,7 +57,7 @@ jobs:
               run: |
                   npm i --ignore-scripts
                   npm run build --if-present
-                  npm pkg delete commitlint devDependencies jest scripts
+                  npm pkg delete commitlint devDependencies scripts
                   npm publish --access public --ignore-scripts --provenance
 
     publish-ghp:
@@ -97,5 +97,5 @@ jobs:
               run: |
                   npm i --ignore-scripts
                   npm run build --if-present
-                  npm pkg delete commitlint devDependencies jest scripts
+                  npm pkg delete commitlint devDependencies scripts
                   npm publish --access public --ignore-scripts --provenance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         if: github.event.pull_request.draft == false
         strategy:
             matrix:
-                node-version: [18, 20, 22]
+                node-version: [20, 22]
                 os: [macos-latest, ubuntu-latest, windows-latest]
         runs-on: ${{ matrix.os }}
         steps:
@@ -117,7 +117,7 @@ jobs:
               run: npm i --ignore-scripts
 
             - name: Run tests
-              run: npm run jest:coverage
+              run: npm run test:unit:coverage
 
             - name: Coveralls parallel
               if: github.repository == 'Fdawgs/fix-latin1-to-utf8'

--- a/package.json
+++ b/package.json
@@ -27,60 +27,39 @@
 	"author": "Frazer Smith <frazer.dev@icloud.com>",
 	"funding": "https://github.com/sponsors/Fdawgs",
 	"engines": {
-		"node": ">=18"
+		"node": ">=20"
 	},
 	"scripts": {
 		"build": "tsc",
-		"jest": "jest",
-		"jest:coverage": "jest --coverage",
 		"lint": "eslint . --cache --ext js,jsx --ignore-path .gitignore",
 		"lint:fix": "npm run lint -- --fix",
 		"lint:licenses": "node scripts/license-checker.js",
 		"lint:prettier": "prettier . -c -u",
 		"lint:prettier:fix": "prettier . -w -u",
 		"prepare": "husky",
-		"test": "npm run lint && npm run lint:prettier && npm run jest"
+		"test": "npm run lint && npm run lint:prettier && npm run test:unit",
+		"test:unit": "node --test",
+		"test:unit:coverage": "c8 --100 --all --src='src/' -r=lcovonly -r=text npm run test:unit"
 	},
 	"commitlint": {
 		"extends": [
 			"@commitlint/config-conventional"
 		]
 	},
-	"jest": {
-		"collectCoverageFrom": [
-			"src/**/*.js"
-		],
-		"coverageReporters": [
-			"text",
-			"lcovonly"
-		],
-		"coverageThreshold": {
-			"global": {
-				"branches": 100,
-				"functions": 100,
-				"lines": 100,
-				"statements": 100
-			}
-		},
-		"testEnvironment": "node",
-		"testTimeout": 10000
-	},
 	"devDependencies": {
 		"@commitlint/cli": "^19.6.1",
 		"@commitlint/config-conventional": "^19.6.0",
 		"@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
-		"@types/jest": "^29.5.14",
+		"c8": "^10.1.3",
 		"eslint": "^8.57.1",
 		"eslint-config-airbnb-base": "^15.0.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-import": "^2.31.0",
-		"eslint-plugin-jest": "^28.10.0",
 		"eslint-plugin-jsdoc": "^50.6.1",
 		"eslint-plugin-promise": "^7.2.1",
 		"eslint-plugin-regexp": "^2.7.0",
 		"eslint-plugin-security": "^3.0.1",
 		"husky": "^9.1.7",
-		"jest": "^29.7.0",
 		"license-checker": "^25.0.1",
 		"prettier": "^3.4.2",
 		"spdx-copyleft": "^1.0.0",

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,25 +1,29 @@
 "use strict";
 
+const { describe, it } = require("node:test");
 const { fixLatin1ToUtf8, replacements } = require("./index");
 
 describe("fixLatin1ToUtf8", () => {
-	it.each(Object.entries(replacements))(
-		"Replaces %s with %s",
-		(actual, expected) => {
-			expect(fixLatin1ToUtf8(actual)).toBe(expected);
-		}
-	);
+	for (const [actual, expected] of Object.entries(replacements)) {
+		it(`Replaces ${actual} with ${expected}`, (t) => {
+			t.plan(1);
+			t.assert.strictEqual(fixLatin1ToUtf8(actual), expected);
+		});
+	}
 
-	it("Replaces multiple characters", () => {
-		expect(fixLatin1ToUtf8("â€šÆ’â€žâ€¦â€\u00A0")).toBe("‚ƒ„…†");
+	it("Replaces multiple characters", (t) => {
+		t.plan(1);
+		t.assert.strictEqual(fixLatin1ToUtf8("â€šÆ’â€žâ€¦â€\u00A0"), "‚ƒ„…†");
 	});
 
-	it("Does not mutate a string without Latin-1 characters", () => {
+	it("Does not mutate a string without Latin-1 characters", (t) => {
+		t.plan(1);
 		const str = "Hello, world!";
-		expect(fixLatin1ToUtf8(str)).toBe(str);
+		t.assert.strictEqual(fixLatin1ToUtf8(str), str);
 	});
 
-	it("Throws an error if the argument is not a string", () => {
-		expect(() => fixLatin1ToUtf8(123)).toThrow(TypeError);
+	it("Throws an error if the argument is not a string", (t) => {
+		t.plan(1);
+		t.assert.throws(() => fixLatin1ToUtf8(123), TypeError);
 	});
 });


### PR DESCRIPTION
BREAKING CHANGE: requires node 20 for node:test functions

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
