### PR TITLE
test(index): use `for` loop over `for...of` loop

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -4,7 +4,10 @@ const { describe, it } = require("node:test");
 const { fixLatin1ToUtf8, replacements } = require("./index");
 
 describe("fixLatin1ToUtf8", () => {
-	for (const [actual, expected] of Object.entries(replacements)) {
+	const entries = Object.entries(replacements);
+	const entriesLength = entries.length;
+	for (let i = 0; i < entriesLength; i += 1) {
+		const [actual, expected] = entries[i];
 		it(`Replaces ${actual} with ${expected}`, (t) => {
 			t.plan(1);
 			t.assert.strictEqual(fixLatin1ToUtf8(actual), expected);


### PR DESCRIPTION
`for...of` [has an iterator overhead](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of#description).

A traditional loop is faster because there are no intermediate objects created or function calls during iteration.
With the length being cached, there are no property lookups either.

See https://github.com/kibertoad/nodejs-benchmark-tournament for supporting benchmarking.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
