### PR TITLE
test(index): remove misleading `mutate` mention

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -21,7 +21,7 @@ describe("fixLatin1ToUtf8", () => {
 		t.assert.strictEqual(fixLatin1ToUtf8("â€šÆ’â€žâ€¦â€\u00A0"), "‚ƒ„…†");
 	});
 
-	it("Does not mutate a string without Latin-1 characters", (t) => {
+	it("Does not alter a string without Latin-1 characters", (t) => {
 		t.plan(1);
 		const str = "Hello, world!";
 		t.assert.strictEqual(fixLatin1ToUtf8(str), str);


### PR DESCRIPTION
Doesn't mutate the original value.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
