### PR TITLE
fix(index): freeze replacements object

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,8 +1,8 @@
 ## Constants
 
 <dl>
-<dt><a href="#replacements">replacements</a> : <code>Record.&lt;string, string&gt;</code></dt>
-<dd><p>Object containing Latin-1 characters and their corresponding UTF-8 characters.</p>
+<dt><a href="#REPLACEMENTS">REPLACEMENTS</a> : <code>Record.&lt;string, string&gt;</code></dt>
+<dd><p>Latin-1 characters and their corresponding UTF-8 characters.</p>
 </dd>
 </dl>
 
@@ -14,10 +14,10 @@
 </dd>
 </dl>
 
-<a name="replacements"></a>
+<a name="REPLACEMENTS"></a>
 
-## replacements : <code>Record.&lt;string, string&gt;</code>
-Object containing Latin-1 characters and their corresponding UTF-8 characters.
+## REPLACEMENTS : <code>Record.&lt;string, string&gt;</code>
+Latin-1 characters and their corresponding UTF-8 characters.
 
 **Kind**: global constant  
 <a name="fixLatin1ToUtf8"></a>

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 "use strict";
 
 /**
- * @description Object containing Latin-1 characters and their corresponding UTF-8 characters.
+ * @description Latin-1 characters and their corresponding UTF-8 characters.
  * @type {Record<string, string>}
  */
-const replacements = {
+const REPLACEMENTS = Object.freeze({
 	// Actual: Expected
 	"â‚¬": "€",
 	"â€š": "‚",
@@ -128,11 +128,11 @@ const replacements = {
 	"Ã½": "ý",
 	"Ã¾": "þ",
 	"Ã¿": "ÿ",
-};
+});
 
 // Cache immutable regex as they are expensive to create and garbage collect
 // eslint-disable-next-line security/detect-non-literal-regexp -- Static regex, no user input
-const matchRegex = new RegExp(Object.keys(replacements).join("|"), "gu");
+const MATCH_REG = new RegExp(Object.keys(REPLACEMENTS).join("|"), "gu");
 
 /**
  * @author Frazer Smith
@@ -147,10 +147,10 @@ function fixLatin1ToUtf8(str) {
 		throw new TypeError("Expected a string");
 	}
 
-	return str.replace(matchRegex, (match) => replacements[match]).normalize();
+	return str.replace(MATCH_REG, (match) => REPLACEMENTS[match]).normalize();
 }
 
 module.exports = fixLatin1ToUtf8; // CommonJS export
 module.exports.default = fixLatin1ToUtf8; // ESM default export
 module.exports.fixLatin1ToUtf8 = fixLatin1ToUtf8; // TypeScript and named export
-module.exports.replacements = replacements;
+module.exports.REPLACEMENTS = REPLACEMENTS;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -2,10 +2,10 @@
 
 // eslint-disable-next-line n/no-unsupported-features/node-builtins -- Tests, not in distributed code
 const { describe, it } = require("node:test");
-const { fixLatin1ToUtf8, replacements } = require("./index");
+const { fixLatin1ToUtf8, REPLACEMENTS } = require("./index");
 
 describe("fixLatin1ToUtf8 function", () => {
-	const entries = Object.entries(replacements);
+	const entries = Object.entries(REPLACEMENTS);
 	const entriesLength = entries.length;
 	for (let i = 0; i < entriesLength; i += 1) {
 		// Destructuring adds overhead, so use index access


### PR DESCRIPTION
Changed cached immutables to UPPER_SNAKECASE as is the style.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
