### PR TITLE
refactor(index): enable regex charset and unicode with `v` flag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ const REPLACEMENTS = Object.freeze({
 
 // Cache immutable regex as they are expensive to create and garbage collect
 // eslint-disable-next-line security/detect-non-literal-regexp -- Static regex, no user input
-const MATCH_REG = new RegExp(Object.keys(REPLACEMENTS).join("|"), "gu");
+const MATCH_REG = new RegExp(Object.keys(REPLACEMENTS).join("|"), "gv");
 
 /**
  * @author Frazer Smith


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
