### PR TITLE
perf(index): add early return on no match

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"@commitlint/cli": "^20.1.0",
 		"@commitlint/config-conventional": "^20.0.0",
 		"@eslint/compat": "^1.3.1",
-		"@fdawgs/eslint-config": "^1.0.2",
+		"@fdawgs/eslint-config": "^1.0.9",
 		"@types/node": "^24.5.2",
 		"c8": "^10.1.3",
 		"eslint": "^9.29.0",

--- a/src/index.js
+++ b/src/index.js
@@ -131,8 +131,9 @@ const REPLACEMENTS = Object.freeze({
 });
 
 // Cache immutable regex as they are expensive to create and garbage collect
+const LATIN1_PATTERN = /[ãâåæë]/iu;
 // eslint-disable-next-line security/detect-non-literal-regexp -- Static regex, no user input
-const MATCH_REG = new RegExp(Object.keys(REPLACEMENTS).join("|"), "gv");
+const MATCH_REG = new RegExp(Object.keys(REPLACEMENTS).join("|"), "gu");
 
 /**
  * @author Frazer Smith
@@ -145,6 +146,11 @@ const MATCH_REG = new RegExp(Object.keys(REPLACEMENTS).join("|"), "gv");
 function fixLatin1ToUtf8(str) {
 	if (typeof str !== "string") {
 		throw new TypeError("Expected a string");
+	}
+
+	// Early return if no matches
+	if (!LATIN1_PATTERN.test(str)) {
+		return str;
 	}
 
 	return str.replace(MATCH_REG, (match) => REPLACEMENTS[match]);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [ ] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [ ] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
