### PR TITLE
chore(index): add error type to throw jsdoc tag

### DIFF
--- a/API.md
+++ b/API.md
@@ -29,7 +29,7 @@ Fixes common encoding errors when converting from Latin-1 (and Windows-1252) to 
 **Returns**: <code>string</code> - The converted string.  
 **Throws**:
 
-- If the argument is not a string.
+- <code>TypeError</code> If the argument is not a string.
 
 **See**: [ UTF-8 Encoding Debugging Chart](http://www.i18nqa.com/debug/utf8-debug.html)  
 **Author**: Frazer Smith  

--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,7 @@ const MATCH_REG = new RegExp(Object.keys(REPLACEMENTS).join("|"), "gu");
  * @see {@link http://www.i18nqa.com/debug/utf8-debug.html | UTF-8 Encoding Debugging Chart}
  * @param {string} str - The string to be converted.
  * @returns {string} The converted string.
- * @throws If the argument is not a string.
+ * @throws {TypeError} If the argument is not a string.
  */
 function fixLatin1ToUtf8(str) {
 	if (typeof str !== "string") {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [ ] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [ ] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
