### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # fix-latin1-to-utf8
 
-[![GitHub release](https://img.shields.io/github/release/Fdawgs/fix-latin1-to-utf8.svg)](https://github.com/Fdawgs/fix-latin1-to-utf8/releases/latest/)
-[![npm version](https://img.shields.io/npm/v/fix-latin1-to-utf8)](https://npmjs.com/package/fix-latin1-to-utf8)
+[![GitHub release](https://img.shields.io/github/v/release/Fdawgs/fix-latin1-to-utf8)](https://github.com/Fdawgs/fix-latin1-to-utf8/releases/latest)
+[![npm version](https://img.shields.io/npm/v/fix-latin1-to-utf8)](https://www.npmjs.com/package/fix-latin1-to-utf8)
 [![CI](https://github.com/Fdawgs/fix-latin1-to-utf8/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Fdawgs/fix-latin1-to-utf8/actions/workflows/ci.yml)
 [![Coverage status](https://coveralls.io/repos/github/Fdawgs/fix-latin1-to-utf8/badge.svg?branch=main)](https://coveralls.io/github/Fdawgs/fix-latin1-to-utf8?branch=main)
-[![code style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat)](https://github.com/prettier/prettier)
+[![code style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4?style=flat)](https://github.com/prettier/prettier)
 [![OSSF Scorecard](https://api.scorecard.dev/projects/github.com/Fdawgs/fix-latin1-to-utf8/badge)](https://scorecard.dev/viewer/?uri=github.com/Fdawgs/fix-latin1-to-utf8)
 
 > Node.js module to fix mojibake when converting Latin-1 encoded text to UTF-8
@@ -45,7 +45,7 @@ Please adhere to this project's [Code of Conduct](https://github.com/Fdawgs/.git
 
 ## Acknowledgements
 
-- **Tex Texin** - Creator of the [UTF-8 Encoding Debugging Chart](http://www.i18nqa.com/debug/utf8-debug.html)
+- **Tex Texin** - Creator of the [UTF-8 Encoding Debugging Chart](https://www.i18nqa.com/debug/utf8-debug.html)
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ const MATCH_REG = new RegExp(Object.keys(REPLACEMENTS).join("|"), "gu");
 /**
  * @author Frazer Smith
  * @description Fixes common encoding errors when converting from Latin-1 (and Windows-1252) to UTF-8.
- * @see {@link http://www.i18nqa.com/debug/utf8-debug.html | UTF-8 Encoding Debugging Chart}
+ * @see {@link https://www.i18nqa.com/debug/utf8-debug.html | UTF-8 Encoding Debugging Chart}
  * @param {string} str - The string to be converted.
  * @returns {string} The converted string.
  * @throws {TypeError} If the argument is not a string.


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup.