### PR TITLE
perf(index): use `null` prototype for faster property lookup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,9 @@
  * @description Latin-1 characters and their corresponding UTF-8 characters.
  * @type {Readonly<Record<string, string>>}
  */
+// @ts-expect-error -- TS cannot infer that __proto__ is a special property and not part of the record type
 const REPLACEMENTS = Object.freeze({
+	__proto__: null,
 	// Actual: Expected
 	"â‚¬": "€",
 	"â€š": "‚",


### PR DESCRIPTION
Slower cold start in exchange for ~50% faster lookup.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`

- [x] Commit message adheres to the [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
