### PR TITLE
docs(readme): correct example output

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Please refer to the [JSDoc comments in the source code](./src/index.js) or the [
 const fixLatin1ToUtf8 = require("fix-latin1-to-utf8");
 
 const latin1String =
-	"This is a UTF-8 string that was converted from Latin-1â€š but the conversion was not great.";
+	"This is a UTF-8 string that was converted from Latin-1, so cafÃ© became mojibake.";
 const utf8String = fixLatin1ToUtf8(latin1String);
 
 console.log(utf8String);
-// This is a UTF-8 string that was converted from Latin-1, but the conversion was not great.
+// This is a UTF-8 string that was converted from Latin-1, so café became mojibake.
 ```
 
 ## Contributing


### PR DESCRIPTION
The example claimed "â€š" becomes a comma.
It maps to U+201A, single low-9 quotation mark, so the printed output never matched the comment.

Swapped it for better example.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
