### PR TITLE
feat(index): correct iso-8859-1 mojibake

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,15 @@
 [![code style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4?style=flat)](https://github.com/prettier/prettier)
 [![OSSF Scorecard](https://api.scorecard.dev/projects/github.com/Fdawgs/fix-latin1-to-utf8/badge)](https://scorecard.dev/viewer/?uri=github.com/Fdawgs/fix-latin1-to-utf8)
 
-> Node.js module to fix mojibake when converting Latin-1 encoded text to UTF-8
+> Node.js module to fix ISO-8859-1 (Latin-1) and Windows-1252 (CP1252) mojibake in UTF-8 strings
 
 # Overview
 
-When converting Latin-1 (or Windows-1252) encoded text to UTF-8, some characters may be incorrectly converted (mojibake). This module fixes those errors.
+Decoding UTF-8 bytes as ISO-8859-1 (Latin-1) or Windows-1252 (CP1252) produces mojibake, where `’` becomes `â€™`.
+Once stored, no charset setting undoes it.
+
+The two encodings garble bytes `0x80`-`0x9F` differently; this module repairs both.
+Windows-1252 is widely treated as an extension of Latin-1, so is covered by this module.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
 	"name": "fix-latin1-to-utf8",
 	"version": "2.0.7",
-	"description": "Fix mojibake when converting Latin-1 encoded text to UTF-8",
+	"description": "Fix ISO-8859-1 (Latin-1) and Windows-1252 (CP1252) mojibake in UTF-8 strings",
 	"keywords": [
+		"cp-1252",
+		"cp1252",
 		"encoding",
 		"iso-8859-1",
+		"iso-88591",
 		"iso8859-1",
+		"iso88591",
 		"latin-1",
 		"latin1",
 		"mojibake",

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,19 @@
 "use strict";
 
 /**
- * @description Latin-1 characters and their corresponding UTF-8 characters.
+ * @description Mojibake sequences and the UTF-8 characters they stand for.
+ * ISO-8859-1 (Latin-1) and Windows-1252 (CP1252) disagree on bytes 0x80-0x9F,
+ * so both readings of every affected character are listed.
+ * @see {@link https://www.i18nqa.com/debug/utf8-debug.html | UTF-8 Encoding Debugging Chart}
+ * @see {@link https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1252.TXT | cp1252 to Unicode table}
+ * @see {@link https://www.unicode.org/Public/MAPPINGS/ISO8859/8859-1.TXT | ISO/IEC 8859-1:1998 to Unicode}
  * @type {Readonly<Record<string, string>>}
  */
 // @ts-expect-error -- TS cannot infer that __proto__ is a special property and not part of the record type
 const REPLACEMENTS = Object.freeze({
 	__proto__: null,
-	// Actual: Expected
+	// Mojibake: original
+	// Windows-1252 mojibake
 	"â‚¬": "€",
 	"â€š": "‚",
 	"Æ’": "ƒ",
@@ -131,19 +137,74 @@ const REPLACEMENTS = Object.freeze({
 	"Ã½": "ý",
 	"Ã¾": "þ",
 	"Ã¿": "ÿ",
+	// ISO-8859-1 mojibake
+	"â\u0082¬": "€",
+	"â\u0080\u009A": "‚",
+	"Æ\u0092": "ƒ",
+	"â\u0080\u009E": "„",
+	"â\u0080¦": "…",
+	"â\u0080\u00A0": "†",
+	"â\u0080¡": "‡",
+	"Ë\u0086": "ˆ",
+	"â\u0080°": "‰",
+	"â\u0080¹": "‹",
+	"Å\u0092": "Œ",
+	"â\u0080\u0098": "‘",
+	"â\u0080\u0099": "’",
+	"â\u0080\u009C": "“",
+	"â\u0080\u009D": "”",
+	"â\u0080¢": "•",
+	"â\u0080\u0093": "–",
+	"â\u0080\u0094": "—",
+	"Ë\u009C": "˜",
+	"â\u0084¢": "™",
+	"â\u0080º": "›",
+	"Å\u0093": "œ",
+	"Ã\u0080": "À",
+	"Ã\u0082": "Â",
+	"Ã\u0083": "Ã",
+	"Ã\u0084": "Ä",
+	"Ã\u0085": "Å",
+	"Ã\u0086": "Æ",
+	"Ã\u0087": "Ç",
+	"Ã\u0088": "È",
+	"Ã\u0089": "É",
+	"Ã\u008A": "Ê",
+	"Ã\u008B": "Ë",
+	"Ã\u008C": "Ì",
+	"Ã\u008E": "Î",
+	"Ã\u0091": "Ñ",
+	"Ã\u0092": "Ò",
+	"Ã\u0093": "Ó",
+	"Ã\u0094": "Ô",
+	"Ã\u0095": "Õ",
+	"Ã\u0096": "Ö",
+	"Ã\u0097": "×",
+	"Ã\u0098": "Ø",
+	"Ã\u0099": "Ù",
+	"Ã\u009A": "Ú",
+	"Ã\u009B": "Û",
+	"Ã\u009C": "Ü",
+	"Ã\u009E": "Þ",
+	"Ã\u009F": "ß",
 });
 
 // Cache immutable regex as they are expensive to create and garbage collect
-const LATIN1_PATTERN = /[ãâåæë]/iu;
+const MOJIBAKE_LEAD_PATTERN = /[ãâåæë]/iu;
+// Sort longest-first so a shorter key cannot shadow a longer one in alternation
 // eslint-disable-next-line security/detect-non-literal-regexp -- Static regex, no user input
-const MATCH_REG = new RegExp(Object.keys(REPLACEMENTS).join("|"), "gu");
+const MATCH_REG = new RegExp(
+	Object.keys(REPLACEMENTS)
+		.sort((a, b) => b.length - a.length)
+		.join("|"),
+	"gu"
+);
 
 /**
  * @author Frazer Smith
- * @description Fixes common encoding errors when converting from Latin-1 (and Windows-1252) to UTF-8.
- * @see {@link https://www.i18nqa.com/debug/utf8-debug.html | UTF-8 Encoding Debugging Chart}
- * @param {string} str - The string to be converted.
- * @returns {string} The converted string.
+ * @description Fixes ISO-8859-1 (Latin-1) and Windows-1252 (CP1252) mojibake in UTF-8 strings.
+ * @param {string} str - The string to be fixed.
+ * @returns {string} The fixed string.
  * @throws {TypeError} If the argument is not a string.
  */
 function fixLatin1ToUtf8(str) {
@@ -152,7 +213,7 @@ function fixLatin1ToUtf8(str) {
 	}
 
 	// Early return if no matches
-	if (!LATIN1_PATTERN.test(str)) {
+	if (!MOJIBAKE_LEAD_PATTERN.test(str)) {
 		return str;
 	}
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,6 +18,17 @@ function mojibakeOf(char) {
 	return windows1252.decode(Buffer.from(char, "utf8"));
 }
 
+/**
+ * @author Frazer Smith
+ * @description Reproduces mojibake by writing the character
+ * out as UTF-8, then reading those bytes back as ISO-8859-1.
+ * @param {string} char - Single character to corrupt.
+ * @returns {string} The mojibake sequence.
+ */
+function isoMojibakeOf(char) {
+	return Buffer.from(char, "utf8").toString("latin1");
+}
+
 describe("fixLatin1ToUtf8 function", () => {
 	const entries = Object.entries(REPLACEMENTS);
 	const entriesLength = entries.length;
@@ -28,34 +39,34 @@ describe("fixLatin1ToUtf8 function", () => {
 		it(`Replaces ${actual} with ${expected}`, (/** @type {TestContext} */ t) => {
 			t.plan(2);
 			t.assert.strictEqual(fixLatin1ToUtf8(actual), expected);
-			t.assert.strictEqual(
-				expected.length,
-				1,
-				"replacement must be a single character"
-			);
+			t.assert.strictEqual(expected.length, 1);
 		});
 	}
 
-	it("REPLACEMENTS lookup covers every Windows-1252 character above ASCII", (/** @type {TestContext} */ t) => {
+	it("REPLACEMENTS covers every Windows-1252 character above ASCII under both decoders, and nothing else", (/** @type {TestContext} */ t) => {
 		t.plan(1);
 		const expectedTable = new Map();
-		/**
-		 * Only bytes 0x80-0xFF can turn into mojibake. Below that is plain ASCII.
-		 * @see {@link https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1252.TXT | cp1252 to Unicode table}
-		 */
+		// Only bytes 0x80-0xFF can turn into mojibake. Below that is plain ASCII
 		for (let byte = 0x80; byte <= 0xff; byte += 1) {
 			const char = windows1252.decode(Buffer.from([byte]));
 			/**
-			 * Skip bytes 0x81, 0x8D, 0x8F, 0x90 and 0x9D, which have no character for
-			 * REPLACEMENTS to map. Node decodes each to the code point of its own
-			 * value (0x81 to U+0081); bytes 0xA0-0xFF do the same but are real
-			 * Latin-1 characters, so keep them.
+			 * Skip bytes 0x81, 0x8D, 0x8F, 0x90 and 0x9D: Windows-1252 leaves them
+			 * unassigned, so there is no character for REPLACEMENTS to recover. Node
+			 * decodes each to the C1 control of its own value (0x81 to U+0081).
+			 * Bytes 0xA0-0xFF also decode to their own value, but as printable
+			 * characters, so those are kept.
 			 * @see {@link https://encoding.spec.whatwg.org/index-windows-1252.txt | windows-1252 index}
 			 */
 			if (byte < 0xa0 && char.charCodeAt(0) === byte) {
 				continue;
 			}
+			/**
+			 * The two decoders only disagree for bytes 0x80-0x9F, so for 74 of the
+			 * 123 characters both calls write the same key with the same value and
+			 * the map settles on 172 entries rather than 246.
+			 */
 			expectedTable.set(mojibakeOf(char), char);
+			expectedTable.set(isoMojibakeOf(char), char);
 		}
 		t.assert.deepStrictEqual(
 			new Map(Object.entries(REPLACEMENTS)),
@@ -68,7 +79,7 @@ describe("fixLatin1ToUtf8 function", () => {
 		t.assert.strictEqual(fixLatin1ToUtf8("â€šÆ’â€žâ€¦â€\u00A0"), "‚ƒ„…†");
 	});
 
-	it("Does not alter a string without Latin-1 characters", (/** @type {TestContext} */ t) => {
+	it("Does not alter a string without mojibake", (/** @type {TestContext} */ t) => {
 		t.plan(1);
 		const str = "Hello, world!";
 		t.assert.strictEqual(fixLatin1ToUtf8(str), str);


### PR DESCRIPTION
Module only originally covered mojibake in the Windows-1252 (CP1252) superset/extension of  ISO-8859-1 (Latin-1) rather than Latin-1 itself. This PR adds support for native Latin-1.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
