### PR TITLE
fix(index): handle multiply encoded mojibake

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,7 +190,7 @@ const REPLACEMENTS = Object.freeze({
 });
 
 // Cache immutable regex as they are expensive to create and garbage collect
-const MOJIBAKE_LEAD_PATTERN = /[ãâåæë]/iu;
+const MOJIBAKE_LEAD_REG = /[âÂÃÅÆË]/u;
 // Sort longest-first to prevent a shorter alternative from matching first
 // eslint-disable-next-line security/detect-non-literal-regexp -- Static regex, no user input
 const MATCH_REG = new RegExp(
@@ -203,9 +203,11 @@ const MATCH_REG = new RegExp(
 /**
  * @author Frazer Smith
  * @description Fixes mojibake caused by decoding UTF-8 bytes
- * as ISO-8859-1 (Latin-1) or Windows-1252 (CP1252).
+ * as ISO-8859-1 (Latin-1) or Windows-1252 (CP1252), including
+ * multiply encoded text.
  * @param {string} str - The string to fix.
- * @returns {string} The fixed string.
+ * @returns {string} The fixed string or the original string
+ * if no known mojibake was found.
  * @throws {TypeError} If `str` is not a string.
  */
 function fixLatin1ToUtf8(str) {
@@ -214,11 +216,19 @@ function fixLatin1ToUtf8(str) {
 	}
 
 	// Early return if no matches
-	if (!MOJIBAKE_LEAD_PATTERN.test(str)) {
+	if (!MOJIBAKE_LEAD_REG.test(str)) {
 		return str;
 	}
 
-	return str.replace(MATCH_REG, (match) => REPLACEMENTS[match]);
+	// Repeat until no known mojibake remains
+	let result = str;
+	let previous;
+	do {
+		previous = result;
+		result = previous.replace(MATCH_REG, (match) => REPLACEMENTS[match]);
+	} while (result !== previous && MOJIBAKE_LEAD_REG.test(result));
+
+	return result;
 }
 
 module.exports = fixLatin1ToUtf8; // CommonJS export

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,7 @@ const windows1252 = new TextDecoder("windows-1252");
  * @param {string} char - Single character to corrupt.
  * @returns {string} The mojibake sequence.
  */
-function mojibakeOf(char) {
+function win1252MojibakeOf(char) {
 	return windows1252.decode(Buffer.from(char, "utf8"));
 }
 
@@ -62,7 +62,10 @@ describe("fixLatin1ToUtf8 function", () => {
 			const originalChar = windows1252.decode(Buffer.from([byte]));
 
 			// Add the mojibake produced by reading the UTF-8 bytes as Windows-1252 and ISO-8859-1
-			expectedReplacements.set(mojibakeOf(originalChar), originalChar);
+			expectedReplacements.set(
+				win1252MojibakeOf(originalChar),
+				originalChar
+			);
 			expectedReplacements.set(isoMojibakeOf(originalChar), originalChar);
 		}
 
@@ -75,6 +78,42 @@ describe("fixLatin1ToUtf8 function", () => {
 	it("Replaces multiple characters", (/** @type {TestContext} */ t) => {
 		t.plan(1);
 		t.assert.strictEqual(fixLatin1ToUtf8("â€šÆ’â€žâ€¦â€\u00A0"), "‚ƒ„…†");
+	});
+
+	it("Is idempotent for adjacent mojibake sequences", (/** @type {TestContext} */ t) => {
+		t.plan(1);
+		// Adjacent replacements can combine into new mojibake, so test every pair
+		const notIdempotent = [];
+		for (let i = 0; i < entriesLength; i += 1) {
+			for (let j = 0; j < entriesLength; j += 1) {
+				const fixed = fixLatin1ToUtf8(entries[i][0] + entries[j][0]);
+				if (fixLatin1ToUtf8(fixed) !== fixed) {
+					notIdempotent.push(fixed);
+				}
+			}
+		}
+
+		t.assert.deepStrictEqual(notIdempotent, []);
+	});
+
+	it("Fixes double-encoded mojibake in a single call", (/** @type {TestContext} */ t) => {
+		t.plan(4);
+		const windows1252Double = win1252MojibakeOf(win1252MojibakeOf("é"));
+		t.assert.strictEqual(windows1252Double, "ÃƒÂ©");
+		t.assert.strictEqual(fixLatin1ToUtf8(windows1252Double), "é");
+
+		const isoDouble = isoMojibakeOf(isoMojibakeOf("é"));
+		t.assert.strictEqual(isoDouble, "Ã\u0083Â©");
+		t.assert.strictEqual(fixLatin1ToUtf8(isoDouble), "é");
+	});
+
+	it("Fixes triple-encoded mojibake in a single call", (/** @type {TestContext} */ t) => {
+		t.plan(2);
+		const windows1252Triple = win1252MojibakeOf(
+			win1252MojibakeOf(win1252MojibakeOf("é"))
+		);
+		t.assert.strictEqual(windows1252Triple, "ÃƒÆ’Ã‚Â©");
+		t.assert.strictEqual(fixLatin1ToUtf8(windows1252Triple), "é");
 	});
 
 	it("Does not alter a string without mojibake", (/** @type {TestContext} */ t) => {


### PR DESCRIPTION
Big shout out to clinical EDRMS and bad data quality for keeping me in a job.

This PR fixes multiply encoded mojibake in a single call by applying replacements until no mojibake remains.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
